### PR TITLE
Do not add trailing newline

### DIFF
--- a/src/content/line.rs
+++ b/src/content/line.rs
@@ -150,9 +150,8 @@ impl Line {
         }
     }
 
-    /// Renders the formatted content of the line to `stdout`.
-    /// The buffer must be flushed to produce output.
-    pub(crate) fn render_with_clear_and_nl(&self, writer: &mut Vec<u8>) {
+    /// Renders the formatted content of the line and clears to end of line.
+    pub(crate) fn render_with_clear(&self, writer: &mut Vec<u8>) {
         let mut writer = VecAsFmtWrite(writer);
 
         for word in &self.0 {
@@ -162,6 +161,13 @@ impl Line {
         Clear(ClearType::UntilNewLine)
             .write_ansi(&mut writer)
             .unwrap();
+    }
+
+    /// Renders the formatted content of the line, clears to end of line,
+    /// then writes a newline and moves to column 0.
+    pub(crate) fn render_with_clear_and_nl(&self, writer: &mut Vec<u8>) {
+        self.render_with_clear(writer);
+        let mut writer = VecAsFmtWrite(writer);
         writeln!(writer).unwrap();
         MoveToColumn(0).write_ansi(&mut writer).unwrap();
     }

--- a/src/content/lines.rs
+++ b/src/content/lines.rs
@@ -321,10 +321,19 @@ impl Lines {
 
     /// Formats and renders all lines to `buffer`.
     /// Notably, this *queues* the lines for rendering.  You must flush the buffer.
+    /// The last line is rendered without a trailing newline so the cursor
+    /// stays on the final canvas row (no blank line below the canvas).
     pub(crate) fn render_from_line(&self, writer: &mut Vec<u8>, start: usize) {
-        for line in self.0.iter().skip(start) {
+        let Some(lines) = self.0.get(start..) else {
+            return;
+        };
+        let Some((last, rest)) = lines.split_last() else {
+            return;
+        };
+        for line in rest {
             line.render_with_clear_and_nl(writer);
         }
+        last.render_with_clear(writer);
     }
 
     /// Render the lines without an escape sequence to clear the line.

--- a/src/superconsole.rs
+++ b/src/superconsole.rs
@@ -21,7 +21,6 @@ use crossterm::terminal::ClearType;
 use crossterm::tty::IsTty;
 
 use crate::Dimensions;
-use crate::Direction;
 use crate::Lines;
 use crate::ansi_support::enable_ansi_support;
 use crate::components::Component;
@@ -240,7 +239,7 @@ impl SuperConsole {
     /// Clears the canvas portion of the superconsole.
     pub fn clear(&mut self) -> Result<(), OutputError> {
         let mut buffer = Vec::new();
-        Self::clear_canvas_pre(&mut buffer, self.canvas_contents.len())?;
+        Self::clear_canvas_pre(&mut buffer, self.canvas_contents.len().saturating_sub(1))?;
         self.canvas_contents = Lines::new();
         Self::clear_canvas_post(&mut buffer)?;
         self.output_mut().output(buffer).map_err(Into::into)
@@ -256,8 +255,7 @@ impl SuperConsole {
         // size so it can be completed in a single syscall otherwise we might see a partially
         // rendered frame.
 
-        // We remove the last line as we always have a blank final line in our output.
-        let size = self.size()?.saturating_sub(1, Direction::Vertical);
+        let size = self.size()?;
 
         self.render_general(root, mode, size)?;
 
@@ -312,7 +310,10 @@ impl SuperConsole {
         let mut buffer = Vec::new();
         buffer.queue(cursor::Hide).map_err(OutputError::Terminal)?;
 
-        Self::clear_canvas_pre(&mut buffer, self.canvas_contents.len() - reuse_prefix)?;
+        Self::clear_canvas_pre(
+            &mut buffer,
+            (self.canvas_contents.len() - reuse_prefix).saturating_sub(1),
+        )?;
 
         if !self.aux_to_emit.is_empty() {
             if self.output().aux_stream_is_tty() {


### PR DESCRIPTION
Before:

<img width="752" height="587" alt="Screenshot 2026-04-08 at 1 14 06 am" src="https://github.com/user-attachments/assets/47364abe-2755-48e2-9dfe-111e546ac22d" />

After:

<img width="752" height="587" alt="Screenshot 2026-04-08 at 1 13 37 am" src="https://github.com/user-attachments/assets/9c088aa7-58cb-4cd9-8a68-ab660582fbed" />

I didn't test it much beyond running "cargo" example, so I'm not sure what may break here.

Feel free to close if current behavior is intentional or there are subtle issues in this PR.